### PR TITLE
Add ca-key flag to enable generating multiple certs from the same CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ certs/leaf.pem: | $(GENERATE_TLS_CERT)
 generate_cert: certs/leaf.pem | $(GENERATE_TLS_CERT)
 ```
 
+There is an optional `--ca-key` flag to use an existing CA key instead of generating one.
+
 ## Client Side
 
 Here's how to make requests that validate, using your new TLS certificates.


### PR DESCRIPTION
I'd like to generate a bunch of client certs all verified by the same CA. This allows you to generate many server and client certs that will all verify against a single CA cert. Default behaviour is unchanged - just adding an extra flag.